### PR TITLE
Stretch fix

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,6 +10,9 @@ location __PATH__ {
   tcp_nodelay on;
   access_log off;
   
+  # Allow shellinabox to use 'eval' without blocking the execution. But keep a warning.
+  add_header Content-Security-Policy-Report-Only "script-src https: 'unsafe-eval'";
+  
   # Include SSOWAT user panel.
   include conf.d/yunohost_panel.conf.inc;
   more_clear_input_headers 'Accept-Encoding';

--- a/conf/shellinabox
+++ b/conf/shellinabox
@@ -15,4 +15,4 @@ SHELLINABOX_PORT=__PORT__
 #
 #   Beeps are disabled because of reports of the VLC plugin crashing
 #   Firefox on Linux/x86_64.
-SHELLINABOX_ARGS="--no-beep --localhost-only"
+SHELLINABOX_ARGS="--no-beep --localhost-only --disable-ssl"

--- a/scripts/install
+++ b/scripts/install
@@ -78,6 +78,7 @@ ynh_replace_string "__PORT__" "$port" "/etc/default/shellinabox"
 
 # Allow the service to log in syslog
 ynh_replace_string " -- -q --background" " -- --background" "/etc/init.d/shellinabox"
+systemctl daemon-reload
 
 systemctl restart shellinabox
 

--- a/scripts/install
+++ b/scripts/install
@@ -75,6 +75,10 @@ ynh_add_nginx_config
 
 cp ../conf/shellinabox /etc/default/shellinabox
 ynh_replace_string "__PORT__" "$port" "/etc/default/shellinabox"
+
+# Allow the service to log in syslog
+ynh_replace_string " -- -q --background" " -- --background" "/etc/init.d/shellinabox"
+
 systemctl restart shellinabox
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -56,6 +56,7 @@ ynh_restore_file "/etc/default/shellinabox"
 
 # Allow the service to log in syslog
 ynh_replace_string " -- -q --background" " -- --background" "/etc/init.d/shellinabox"
+systemctl daemon-reload
 
 systemctl restart shellinabox
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -53,6 +53,10 @@ ynh_package_install shellinabox
 
 ynh_restore_file "/etc/shellinabox"
 ynh_restore_file "/etc/default/shellinabox"
+
+# Allow the service to log in syslog
+ynh_replace_string " -- -q --background" " -- --background" "/etc/init.d/shellinabox"
+
 systemctl restart shellinabox
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -59,3 +59,12 @@ ynh_add_nginx_config
 #=================================================
 
 systemctl reload nginx
+
+#=================================================
+# ALLOW THE SERVICE TO LOG IN SYSLOG
+#=================================================
+
+ynh_replace_string " -- -q --background" " -- --background" "/etc/init.d/shellinabox"
+systemctl daemon-reload
+
+systemctl restart shellinabox


### PR DESCRIPTION
## Problem
- *Shellinabox doesn't work on stretch, error 502*

## Solution
- *Add the argument `disable-ssl` to prevent an error with the reverse-proxy which use http. [Official doc](https://github.com/shellinabox/shellinabox/blob/e6c25e84bc662797c7382500f136bb74874c2500/shellinabox/shellinaboxd.man.in#L638-L641)*
- *Allow eval in nginx header, otherwise shellinabox will be stuck with a blank page and nothing else.*
- *Remove this fucking `--quiet` in the sysvinit script, because trying to debug without a log isn't really easy...*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : JimboJoe
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20stretch_fix%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20stretch_fix%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.