### PR TITLE
Testing

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,25 @@
+## Problem
+- *Description of why you made this PR*
+
+## Solution
+- *And how you fix that*
+
+## PR Status
+- [ ] Code finished.
+- [ ] Tested with Package_check.
+- [ ] Fix or enhancement tested.
+- [ ] Upgrade from last version tested.
+- [ ] Can be reviewed and tested.
+
+## Validation
+---
+*Minor decision*
+- **Upgrade previous version** : 
+- [ ] **Code review** : 
+- [ ] **Approval (LGTM)** : 
+- [ ] **Approval (LGTM)** : 
+- **CI succeeded** : 
+[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20-BRANCH-%20(Official)/) *Please replace '-BRANCH-' in this link for a PR from a local branch.*  
+or  
+[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20PR-NUM-%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20PR-NUM-%20(Official_fork)/) *Replace '-NUM-' by the PR number in this link for a PR from a forked repository.*  
+When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -59,12 +59,25 @@ ynh_add_nginx_config
 #=================================================
 
 systemctl reload nginx
-
 #=================================================
-# ALLOW THE SERVICE TO LOG IN SYSLOG
+# CONFIGURE SHELLINABOX
 #=================================================
 
+# Verify the checksum and backup the file if it's different
+ynh_backup_if_checksum_is_different "/etc/default/shellinabox"
+
+cp ../conf/shellinabox /etc/default/shellinabox
+ynh_replace_string "__PORT__" "$port" "/etc/default/shellinabox"
+
+# Allow the service to log in syslog
 ynh_replace_string " -- -q --background" " -- --background" "/etc/init.d/shellinabox"
 systemctl daemon-reload
 
 systemctl restart shellinabox
+
+#=================================================
+# STORE THE CHECKSUM OF THE CONFIG FILE
+#=================================================
+
+# Calculate and store the config file checksum into the app settings
+ynh_store_file_checksum "/etc/default/shellinabox"


### PR DESCRIPTION
## Problem
- *`--disable-ssl` is missing in `/etc/default/shellinabox` after an upgrade.*

## Solution
- *Rewrite config during the upgrade*
- *Fix https://github.com/YunoHost-Apps/shellinabox_ynh/issues/9*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe from #10
- [x] **Approval (LGTM)** : JimboJoe from #10
- [x] **Approval (LGTM)** : Josué from #10
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20testing%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/shellinabox_ynh%20testing%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.