### PR TITLE
Make Shellinabox Rebootproof no matter config file

### DIFF
--- a/conf/shellinabox.service
+++ b/conf/shellinabox.service
@@ -1,0 +1,38 @@
+# Make it bootable at startup
+[Install]
+WantedBy=multi-user.target
+
+[Unit]
+Documentation=man:shellinaboxd(1)
+
+# Sourcing LSB Path
+SourcePath=/etc/init.d/shellinabox
+Description=LSB: Shell In A Box Daemon
+Before=multi-user.target
+Before=graphical.target
+After=network-online.target
+
+# Awaits LDAP is specific user binding at startup
+After=slapd.service
+After=remote-fs.target
+Wants=network-online.target
+Requires=slapd.service
+
+[Service]
+Type=forking
+
+# Calls for restart when there is a fail
+Restart=on-failure
+RestartSec=5min
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=no
+SuccessExitStatus=5 6
+
+# Gracefully wait for every service to come up
+ExecStartPre=/bin/sleep 3
+ExecStart=/etc/init.d/shellinabox start
+ExecStop=/etc/init.d/shellinabox stop
+ExecReload=/etc/init.d/shellinabox reload

--- a/scripts/backup
+++ b/scripts/backup
@@ -33,6 +33,7 @@ ynh_script_progression --message="Backing up the main app directory..."
 
 ynh_backup --src_path="/etc/shellinabox"
 ynh_backup --src_path="/etc/default/shellinabox"
+ynh_backup --src_path="/etc/systemd/system/shellinabox.service"
 
 #=================================================
 # BACKUP THE NGINX CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -77,10 +77,14 @@ ynh_script_progression --message="Configuring shellinabox..." --weight=2
 cp ../conf/shellinabox /etc/default/shellinabox
 ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="/etc/default/shellinabox"
 
+
 # Allow the service to log in syslog
 ynh_replace_string --match_string=" -- -q --background" --replace_string=" -- --background" --target_file="/etc/init.d/shellinabox"
-systemctl daemon-reload
 
+# Enable SystemD respawn feature and boot order to avoid premature crashs
+cp ../conf/shellinabox.service /etc/systemd/system/shellinabox.service
+
+systemctl daemon-reload
 ynh_systemd_action --service_name=shellinabox --action=restart
 
 #=================================================
@@ -89,6 +93,7 @@ ynh_systemd_action --service_name=shellinabox --action=restart
 
 # Calculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file="/etc/default/shellinabox"
+ynh_store_file_checksum --file="/etc/systemd/system/shellinabox.service"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -38,6 +38,9 @@ ynh_script_progression --message="Removing shellinabox..." --weight=20
 
 ynh_package_autopurge shellinabox
 
+# Remove Systemd auto-created daemon
+rm -f /etc/systemd/system/shellinabox.service
+
 #=================================================
 # REMOVE NGINX CONFIGURATION
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -57,6 +57,7 @@ ynh_script_progression --message="Restoring the app main directory..." --weight=
 
 ynh_restore_file --origin_path="/etc/shellinabox"
 ynh_restore_file --origin_path="/etc/default/shellinabox"
+ynh_restore_file --origin_path="/etc/systemd/system/shellinabox.service"
 
 # Allow the service to log in syslog
 ynh_replace_string --match_string=" -- -q --background" --replace_string=" -- --background" --target_file="/etc/init.d/shellinabox"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -68,9 +68,12 @@ ynh_script_progression --message="Upgrading shellinabox configuration..." --weig
 
 # Verify the checksum and backup the file if it's different
 ynh_backup_if_checksum_is_different --file="/etc/default/shellinabox"
+ynh_backup_if_checksum_is_different --file="/etc/systemd/system/shellinabox.service"
 
 cp ../conf/shellinabox /etc/default/shellinabox
 ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="/etc/default/shellinabox"
+
+cp ../conf/shellinabox.service /etc/systemd/system/shellinabox.service
 
 ynh_replace_string --match_string=" -- -q --background" --replace_string=" -- --background" --target_file="/etc/init.d/shellinabox"
 systemctl daemon-reload


### PR DESCRIPTION
## Problem
- In certain conditions, such as configuring a dedicated user for
Shellinabox, system tend to crash or not to be reboot proof.

- For example by adding "-s /:myuser:myuser:HOME:SHELL" to
Shellinabox command-line result in non-reboot-proof situation.

- This is however convenient to avoid typing multiple passwords after
SSOWat.

- This is because Shellinaboxd starts before essential elements, such as
slapd, and can't recover from failure.

## Solution
- Adding feature enables Respawn directove to be handled by SystemD.
- Boot order is placed after YunoHost's Slapd start. Please see PR included.

## PR Status
- [X] Code finished.
- [X] Tested with Package_check.
- [ ] Fix or enhancement tested. => NO CLEAN ENV
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [X] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** :
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/shellinabox_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/shellinabox_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
